### PR TITLE
Upgrade Gradle Wrapper to 6.8.1 in 03-BuildAutomation/workspace/22-Scans

### DIFF
--- a/03-BuildAutomation/workspace/22-Scans/gradle/wrapper/gradle-wrapper.properties
+++ b/03-BuildAutomation/workspace/22-Scans/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle wrapper in 03-BuildAutomation/workspace/22-Scans 6.8 -> 6.8.1.